### PR TITLE
Add baseline model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     author_email='',
     # REPLACE WITH YOUR OWN GITHUB PROJECT LINK
     url='https://github.com/annikabrundyn/da_vinci',
-    install_requires=['pytorch-lightning'],
-    packages=find_packages(),
+    package_dir={"": "src"},
+    packages=find_packages("src"),
 )

--- a/src/data/baseline_dataset.py
+++ b/src/data/baseline_dataset.py
@@ -1,0 +1,213 @@
+import math
+import os
+import pytorch_lightning as pl
+import random
+
+from PIL import Image
+from sklearn.utils import shuffle
+from torch.utils.data import DataLoader
+from torch.utils.data import Dataset
+from torchvision import transforms
+
+
+
+class BaselineDaVinciDataSet(Dataset):
+
+    def __init__(self,
+                 data_dir: str,
+                 sample_list: list,
+                 img_transform = None,
+                 target_transform = None
+                 ):
+        self.data_dir = data_dir
+        self.sample_list = sample_list
+
+        if not img_transform:
+            self.img_transform = transforms.Compose([transforms.ToTensor()])
+        else:
+            self.img_transform = img_transform
+
+        if not target_transform:
+            self.target_transform = transforms.Compose([transforms.ToTensor()])
+        else:
+            self.target_transform = target_transform
+
+    def __len__(self):
+        return len(self.sample_list)
+
+    def __getitem__(self, index):
+        image_set, frame = self.sample_list[index]
+        assert len(frame) == 1
+        frame = frame[0]
+
+        img_path = os.path.join(self.data_dir, "{:s}".format(image_set), 'image_0', "{:s}".format(frame))
+        image = Image.open(img_path)
+        image = self.img_transform(image)
+
+        # target is only the first frame
+        target_path = os.path.join(self.data_dir, "{:s}".format(image_set), 'image_1', "{:s}".format(frame))
+        target = Image.open(target_path)
+        target = self.target_transform(target)
+
+
+        return image, target
+
+
+class BaselineDaVinciDataModule(pl.LightningDataModule):
+    def __init__(
+            self,
+            data_dir: str,
+            frames_per_sample: int = 1,
+            val_split: float = 0.2,
+            test_split: float = 0.1,
+            num_workers: int = 16,
+            batch_size: int = 16,
+            num_pred_img_samples: int = 15,
+            *args,
+            **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.data_dir = data_dir if data_dir is not None else os.getcwd()
+        self.frames_per_sample = frames_per_sample
+        self.val_split = val_split
+        self.test_split = test_split
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.num_pred_img_samples = num_pred_img_samples
+
+    # helper
+    def _read_image_list(self, filename):
+        list_file = open(filename, 'r')
+        img_list = []
+        while True:
+            next_line = list_file.readline()
+            if not next_line:
+                break
+            png_name = next_line.rstrip()
+
+            img_list.append(png_name)
+        return img_list
+
+    # helper
+    def _split_into_chunks(self, img_list, window_size, name):
+        all_samples = []
+        for i in range(0, len(img_list) - window_size, window_size):
+            if i + 2*window_size > len(img_list):  #if its the last sample
+                all_samples.append((name, img_list[i:]))
+            else:
+                all_samples.append((name, img_list[i: i+window_size]))
+        return all_samples
+
+    # helper
+    def _sliding_window(self, img_sets, val_set=False):
+        # create samples containing k frames per sample and dropping some number of random frames
+        split_samples = []
+        step_size = 1  # sample overlap size
+
+        for (name, frame_list) in img_sets:
+            for i in range(0, len(frame_list)-self.frames_per_sample+1, step_size):
+                frames = frame_list[i:i+self.frames_per_sample]
+                # Randomly drop frames - only do this if we have 3 or more frames
+                if self.frames_per_sample > 2:
+                    max_frames_to_drop = self.frames_per_sample - 2  # cant drop more than this
+                    if self.frames_to_drop > max_frames_to_drop:
+                        #TODO: Add warning if user input more frames to drop than makes sense
+                        self.frames_to_drop = max_frames_to_drop
+                    for i in range(self.frames_to_drop):
+                        rand_idx = random.randint(1, len(frames) - 1)
+                        _ = frames.pop(rand_idx)
+                split_samples += [(name, frames)]
+
+                if val_set and (name, frames[0]) in self.vis_img_list_names:
+                    self.vis_img_list += [(name, frames)]
+
+        return split_samples
+
+    # helper
+    def _create_val_img_list(self, val_sets):
+        vis_img_list_names = []
+        random_seed_list = range(2020, 2020+self.num_pred_img_samples)
+
+        for i in random_seed_list:
+            random.seed(i)
+            s = random.choice(val_sets)
+            name = s[0]
+            frame = random.choice(s[1])
+            vis_img_list_names.append((name, frame))
+
+        return vis_img_list_names
+
+
+    def setup(self):
+        # this function does the train/val/test splits - needs to be run first after instantiating dm
+        train_img_list = self._read_image_list(os.path.join(self.data_dir, 'train.txt'))
+        train_img_list = train_img_list[::-1]
+        all_sets = self._split_into_chunks(train_img_list, window_size=1000, name='train')
+
+        test_img_list = self._read_image_list(os.path.join(self.data_dir, 'test.txt'))
+        test_img_list = test_img_list[::-1]
+        all_sets += self._split_into_chunks(test_img_list, window_size=1000, name='test')
+
+        # shuffle all 41 sets of 1000 frames
+        self.all_sets = shuffle(all_sets, random_state=42)
+
+        # split train/val/test
+        val_len = math.floor(self.val_split * len(self.all_sets))
+        test_len = math.floor(self.test_split * len(self.all_sets))
+        train_len = len(self.all_sets) - val_len - test_len
+
+        self.train_sets = self.all_sets[:train_len]
+        self.val_sets = self.all_sets[train_len:train_len+val_len]
+        self.test_sets = self.all_sets[-test_len:]
+
+        # create separate list of random images from validation set to predict on at the end of training
+        self.vis_img_list_names = self._create_val_img_list(self.val_sets)
+        self.vis_img_list = []
+
+        self.train_samples = self._sliding_window(self.train_sets)
+        self.val_samples = self._sliding_window(self.val_sets, val_set=True)
+        self.test_samples = self._sliding_window(self.test_sets)
+
+        self.train_samples = shuffle(self.train_samples, random_state=42)
+        self.val_samples = shuffle(self.val_samples, random_state=42)
+        self.test_samples = shuffle(self.test_samples, random_state=42)
+
+        self.train_dataset = BaselineDaVinciDataSet(data_dir=self.data_dir,
+                                            sample_list=self.train_samples)
+
+        self.val_dataset = BaselineDaVinciDataSet(data_dir=self.data_dir,
+                                          sample_list=self.val_samples)
+
+        self.test_dataset = BaselineDaVinciDataSet(data_dir=self.data_dir,
+                                           sample_list=self.test_samples)
+
+        self.vis_dataset = BaselineDaVinciDataSet(data_dir=self.data_dir,
+                                          sample_list=self.vis_img_list)
+
+    def train_dataloader(self):
+        loader = DataLoader(self.train_dataset,
+                            batch_size=self.batch_size,
+                            shuffle=True,
+                            num_workers=self.num_workers)
+        return loader
+
+    def val_dataloader(self):
+        loader = DataLoader(self.val_dataset,
+                            batch_size=self.batch_size,
+                            shuffle=False,
+                            num_workers=self.num_workers)
+        return loader
+
+    def test_dataloader(self):
+        loader = DataLoader(self.test_dataset,
+                            batch_size=self.batch_size,
+                            shuffle=False,
+                            num_workers=self.num_workers)
+        return loader
+
+    def vis_img_dataloader(self):
+        loader = DataLoader(self.vis_dataset,
+                            batch_size=1,
+                            shuffle=False,
+                            num_workers=self.num_workers)
+        return loader

--- a/src/models/baseline_model.py
+++ b/src/models/baseline_model.py
@@ -49,6 +49,12 @@ def x_trans_slice(img_slice, x_vox_trans):
 def calc_mae_translation(img, target, mae_list, args):
     index = args[0]
     translation = args[1]
+
+    img = img.numpy()
+    target = target.numpy()
+    img = img.transpose(1, 2, 0)
+    target = target.transpose(1, 2, 0)
+
     # Make the translated image Y_t
     shifted = x_trans_slice(img, translation)
     # Calculate the mismatch
@@ -74,11 +80,6 @@ class BaselineModel:
             for batch_idx, batch in enumerate(tqdm(dataloader)):
                 imgs, targets = batch
                 for img, target in zip(imgs, targets):
-                    img = img.numpy()
-                    target = target.numpy()
-                    img = img.transpose(1, 2, 0)
-                    target = target.transpose(1, 2, 0)
-
                     func = partial(calc_mae_translation, img, target, mae_list)
                     p.map(func, enumerate(translations))
         p.close()

--- a/src/models/baseline_model.py
+++ b/src/models/baseline_model.py
@@ -81,7 +81,6 @@ class BaselineModel:
 
                     func = partial(calc_mae_translation, img, target, mae_list)
                     p.map(func, enumerate(translations))
-                break
         p.close()
         p.join()
 

--- a/src/models/baseline_model.py
+++ b/src/models/baseline_model.py
@@ -10,10 +10,12 @@ from argparse import ArgumentParser
 from data.baseline_dataset import BaselineDaVinciDataModule
 from torch.utils.data import DataLoader
 
+
 def mean_abs_mismatch(slice0, slice1):
     """ Mean absoute difference between images
     """
     return np.mean(np.abs(slice0 - slice1))
+
 
 def x_trans_slice(img_slice, x_vox_trans):
     """ Return copy of `img_slice` translated by `x_vox_trans` voxels
@@ -43,6 +45,7 @@ def x_trans_slice(img_slice, x_vox_trans):
         trans_slice[:, x_vox_trans:, :] = img_slice[:, :-x_vox_trans, :]
     return trans_slice
 
+
 def calc_mae_translation(img, target, mae_list, args):
     index = args[0]
     translation = args[1]
@@ -51,6 +54,7 @@ def calc_mae_translation(img, target, mae_list, args):
     # Calculate the mismatch
     mae = mean_abs_mismatch(shifted, target)
     mae_list[index] += mae
+
 
 class BaselineModel:
     INPUT_IMG_WIDTH = 384
@@ -72,8 +76,8 @@ class BaselineModel:
                 for img, target in zip(imgs, targets):
                     img = img.numpy()
                     target = target.numpy()
-                    img = img.transpose(1,2,0)
-                    target = target.transpose(1,2,0)
+                    img = img.transpose(1, 2, 0)
+                    target = target.transpose(1, 2, 0)
 
                     func = partial(calc_mae_translation, img, target, mae_list)
                     p.map(func, enumerate(translations))
@@ -119,8 +123,7 @@ if __name__ == "__main__":
     min_mae = model.fit(dm.val_dataloader())
     global_disparity = model.global_disparity
 
-    with open('baseline_results.txt', 'w') as f:
-        sys.stdout = f # Change the standard output to the file we created.
+    with open("baseline_results.txt", "w") as f:
+        sys.stdout = f  # Change the standard output to the file we created.
         print(f"min mae: {min_mae}")
         print(f"best global disparity: {global_disparity}")
-

--- a/src/models/baseline_model.py
+++ b/src/models/baseline_model.py
@@ -1,0 +1,126 @@
+import multiprocessing
+import numpy as np
+import pytorch_lightning as pl
+import sys
+
+from functools import partial
+from tqdm import tqdm
+
+from argparse import ArgumentParser
+from data.baseline_dataset import BaselineDaVinciDataModule
+from torch.utils.data import DataLoader
+
+def mean_abs_mismatch(slice0, slice1):
+    """ Mean absoute difference between images
+    """
+    return np.mean(np.abs(slice0 - slice1))
+
+def x_trans_slice(img_slice, x_vox_trans):
+    """ Return copy of `img_slice` translated by `x_vox_trans` voxels
+
+    Parameters
+    ----------
+    img_slice : array shape (H, W, num_channels)
+        2D image to transform with translation `x_vox_trans`
+    x_vox_trans : int
+        Number of pixels (voxels) to translate `img_slice`; can be
+        positive or negative.
+
+    Returns
+    -------
+    img_slice_transformed : array shape (M, N)
+        2D image translated by `x_vox_trans` pixels (voxels).
+    """
+    # Make a 0-filled array of same shape as `img_slice`
+    trans_slice = np.zeros(img_slice.shape)
+    # Use slicing to select voxels out of the image and move them
+    # up or down on the first (x) axis
+    if x_vox_trans < 0:
+        trans_slice[:, :x_vox_trans, :] = img_slice[:, -x_vox_trans:, :]
+    elif x_vox_trans == 0:
+        trans_slice[:, :, :] = img_slice
+    else:
+        trans_slice[:, x_vox_trans:, :] = img_slice[:, :-x_vox_trans, :]
+    return trans_slice
+
+def calc_mae_translation(img, target, mae_list, args):
+    index = args[0]
+    translation = args[1]
+    # Make the translated image Y_t
+    shifted = x_trans_slice(img, translation)
+    # Calculate the mismatch
+    mae = mean_abs_mismatch(shifted, target)
+    mae_list[index] += mae
+
+class BaselineModel:
+    INPUT_IMG_WIDTH = 384
+
+    def __init__(self):
+        self.global_disparity = 0
+
+    def fit(self, dataloader: DataLoader):
+        half_width = int(self.INPUT_IMG_WIDTH / 2)
+        translations = range(-half_width, half_width)  # Candidate values for t
+
+        manager = multiprocessing.Manager()
+        mae_list = manager.list([0] * len(translations))
+        p = multiprocessing.Pool()
+
+        with p:
+            for batch_idx, batch in enumerate(tqdm(dataloader)):
+                imgs, targets = batch
+                for img, target in zip(imgs, targets):
+                    img = img.numpy()
+                    target = target.numpy()
+                    img = img.transpose(1,2,0)
+                    target = target.transpose(1,2,0)
+
+                    func = partial(calc_mae_translation, img, target, mae_list)
+                    p.map(func, enumerate(translations))
+                break
+        p.close()
+        p.join()
+
+        mae_list = np.array(mae_list)
+        mae = mae_list / len(dataloader.dataset)
+        min_mae_pos = mae.argmin()
+        self.global_disparity = translations[min_mae_pos]
+        return mae[min_mae_pos]
+
+
+if __name__ == "__main__":
+    # sets seed for numpy, torch, python.random and PYTHONHASHSEED
+    pl.seed_everything(42)
+
+    parser = ArgumentParser()
+    parser.add_argument("--data_dir", type=str, help="path to davinci data")
+
+    args = parser.parse_args()
+
+    # data
+    dm = BaselineDaVinciDataModule(args.data_dir)
+    dm.setup()
+    print("dm setup")
+
+    # sanity check
+    print("size of trainset:", len(dm.train_samples))
+    print("size of validset:", len(dm.val_samples))
+    print("size of testset:", len(dm.test_samples))
+
+    img, target = next(iter(dm.val_dataloader()))
+    print(img.shape)
+    print(target.shape)
+
+    # model
+    model = BaselineModel()
+    print("model instance created")
+
+    # train
+    min_mae = model.fit(dm.val_dataloader())
+    global_disparity = model.global_disparity
+
+    with open('baseline_results.txt', 'w') as f:
+        sys.stdout = f # Change the standard output to the file we created.
+        print(f"min mae: {min_mae}")
+        print(f"best global disparity: {global_disparity}")
+

--- a/src/models/lr_model.py
+++ b/src/models/lr_model.py
@@ -2,9 +2,9 @@ from argparse import ArgumentParser
 
 import pytorch_lightning as pl
 
-from src.models.unet import UNet
-from src.data.data import DaVinciDataModule
-from src.models.model import DepthMap
+from models.unet import UNet
+from data.data import DaVinciDataModule
+from models.model import DepthMap
 
 
 class LeftRightDepthMap(DepthMap):

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -6,9 +6,9 @@ import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
 
-from src.models.unet import UNet
-from src.metrics.fid import calculate_fid
-from src.data.data import DaVinciDataModule
+from models.unet import UNet
+from metrics.fid import calculate_fid
+from data.data import DaVinciDataModule
 
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import ImageGrid

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -1,5 +1,5 @@
 import os
-from src.data.data import DaVinciDataModule
+from data.data import DaVinciDataModule
 
 DATA_DIR = "//daVinci_data"
 

--- a/tests/metrics/test_fid.py
+++ b/tests/metrics/test_fid.py
@@ -2,7 +2,7 @@ import os
 from PIL import Image
 from torchvision import transforms
 
-from src.metrics.fid import calculate_fid
+from metrics.fid import calculate_fid
 
 FIXTURES_DIR = "test_fid_fixtures"
 


### PR DESCRIPTION
The baseline model is a global disparity shift where we take the left image and shift it in the range of [-192, 192]. We calculate the lowest MAE and global disparity on the validation set (same as Deep3D) for these shifts and output the results to a file. This does not yet support evaluation on a test set. Baseline dataloaders are similar to the other datasets so we can use the same data splits here.

Run using:
`python src/models/baseline_model.py --data_dir ~/nyu_ms_ds/capstone/daVinci `