### PR TITLE
Change FID to run per epoch and for a specified num_batches

### DIFF
--- a/src/data/data.py
+++ b/src/data/data.py
@@ -268,7 +268,7 @@ class DaVinciDataModule(pl.LightningDataModule):
     def val_dataloader(self):
         loader = DataLoader(self.val_dataset,
                             batch_size=self.batch_size,
-                            shuffle=False,
+                            shuffle=True,
                             num_workers=self.num_workers)
         return loader
 

--- a/src/models/callbacks/fid_callback.py
+++ b/src/models/callbacks/fid_callback.py
@@ -1,29 +1,41 @@
+import logging
+
 from pytorch_lightning.callbacks import Callback
 from metrics.fid import calculate_fid
+from pytorch_fid.inception import InceptionV3
+
+
+def log_fid(trainer, pl_module, dataloader, set_name, num_batches, inception_model):
+    dl_iter = iter(dataloader)
+    for i in range(num_batches):
+        img, target, extra_info = next(dl_iter)
+        pred = pl_module(img.to(pl_module.device))
+        try:
+            fid_val = calculate_fid(pred, target, is_color=pl_module.is_color_output, device=pl_module.device, inception_model=inception_model)
+            pl_module.logger.log_metrics({f"{set_name}_fid": fid_val}, trainer.global_step)
+        except ValueError:
+            logging.warning('Error encountered in FID calculation!')
 
 
 class FidCallback(Callback):
-    def __init__(self, train_dl, valid_dl, epoch_logging_freq: int = 1):
+    def __init__(self, train_dl, valid_dl, train_epoch_freq: int = 1, valid_epoch_freq: int = 1, num_train_batches: int = 1, num_valid_batches: int = 1, dims=2048):
         self.train_dl = train_dl
         self.valid_dl = valid_dl
-        self.epoch_logging_freq = epoch_logging_freq
+        self.train_epoch_freq = train_epoch_freq
+        self.valid_epoch_freq = valid_epoch_freq
+        self.num_train_batches = num_train_batches
+        self.num_valid_batches = num_valid_batches
+
+        block_idx = InceptionV3.BLOCK_INDEX_BY_DIM[dims]
+        self.inception_model = InceptionV3([block_idx])
 
     def on_train_epoch_end(self, trainer, pl_module, outputs):
-        img, target, extra_info = next(iter(self.valid_dl))
-        pred = pl_module(img.to(pl_module.device))
-        if trainer.current_epoch % self.epoch_logging_freq == 0:
-            try:
-                fid_val = calculate_fid(pred, target, is_color=pl_module.is_color_output, device=pl_module.device)
-            except ValueError:
-                fid_val = -1
-            pl_module.logger.experiment.add_scalar("train_fid", fid_val, trainer.global_step)
+        if trainer.current_epoch % self.train_epoch_freq == 0:
+            log_fid(trainer, pl_module, self.train_dl, "train", self.num_train_batches, self.inception_model)
 
     def on_validation_epoch_end(self, trainer, pl_module):
-        img, target, extra_info = next(iter(self.valid_dl))
-        pred = pl_module(img.to(pl_module.device))
-        if trainer.current_epoch % self.epoch_logging_freq == 0:
-            try:
-                fid_val = calculate_fid(pred, target, is_color=pl_module.is_color_output, device=pl_module.device)
-            except ValueError:
-                fid_val = -1
-            pl_module.logger.experiment.add_scalar("valid_fid", fid_val, trainer.global_step)
+        if trainer.current_epoch % self.valid_epoch_freq == 0:
+            log_fid(trainer, pl_module, self.valid_dl, "valid", self.num_valid_batches, self.inception_model)
+
+    def on_fit_end(self, trainer, pl_module):
+        log_fid(trainer, pl_module, self.valid_dl, "final_valid", len(self.valid_dl), self.inception_model)


### PR DESCRIPTION
This PR

1. Changes the default device for FID to cuda
2. Creates the inception model once instead of every `calculate_fid()`
3. Shuffles the  validation dataloader for randomized fid calculations
4. Changes FID to run per num_epochs and for num_batches