### PR TITLE
Convert baseline model to pytorch. Add loss registry.

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,1 +1,0 @@
-from data.multiframe_data import StackedDaVinciDataModule, UnstackedDaVinciDataModule

--- a/src/data/data.py
+++ b/src/data/data.py
@@ -110,6 +110,7 @@ class DaVinciDataModule(pl.LightningDataModule):
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.num_pred_img_samples = num_pred_img_samples
+        self.dataset = DaVinciDataSet
 
     # helper
     def _read_image_list(self, filename):

--- a/src/losses/__init__.py
+++ b/src/losses/__init__.py
@@ -1,2 +1,3 @@
 from losses.perceptual_loss import Perceptual
 from losses.custom_loss import L1_Perceptual, L1_SSIM
+from losses.loss_registry import LossRegistry

--- a/src/losses/custom_loss.py
+++ b/src/losses/custom_loss.py
@@ -1,12 +1,22 @@
-import torch
+from pytorch_lightning.metrics import SSIM
+from losses.loss_registry import LossRegistry
+from losses.perceptual_loss import Perceptual
 from torch import nn
 import torch.nn.functional as F
 
 from losses.perceptual_loss import Perceptual
 from pytorch_lightning.metrics.functional import ssim
+import torch
+import abc
 
 
-class L1_Perceptual(nn.Module):
+class CustomLoss(nn.Module):
+    def reset(self):
+        pass
+
+
+# @LossRegistry.register('l1_perceptual')
+class L1_Perceptual(CustomLoss):
     def __init__(self) -> None:
         '''
         Equal weight for L1 + Perceptual Loss
@@ -19,7 +29,8 @@ class L1_Perceptual(nn.Module):
         return self.l1(y_true, y_pred) + self.perceptual(y_true, y_pred)
 
 
-class L1_SSIM(nn.Module):
+@LossRegistry.register('l1_ssim')
+class L1_SSIM(CustomLoss):
     def __init__(self) -> None:
         '''
         Equal weight for L1 + SSIM
@@ -28,3 +39,4 @@ class L1_SSIM(nn.Module):
 
     def forward(self, y_true: torch.Tensor, y_pred: torch.Tensor) -> torch.Tensor:
         return F.l1_loss(y_true, y_pred) + ssim(y_true, y_pred)
+

--- a/src/losses/perceptual_loss.py
+++ b/src/losses/perceptual_loss.py
@@ -1,4 +1,6 @@
 import torch
+
+from losses.loss_registry import LossRegistry
 from torch import nn
 from torch.nn import functional as F
 from torchvision import models
@@ -25,6 +27,7 @@ class VGG16FeatureExtractor(nn.Module):
         return results[1:]
 
 
+# @LossRegistry.register('perceptual')
 class Perceptual(nn.Module):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
This PR adds the initial baseline model as well as a loss registry. The loss registry should be used to create custom losses as these will be immediately added to the baseline model. See comments in code for additional details.

Currently only one loss is implemented in the registry. Other losses can easily be added by adding them with the decorator (see comments in code).